### PR TITLE
🐛 hide stop and get logs button if not in context

### DIFF
--- a/packages/webapp/src/components/Actions.js
+++ b/packages/webapp/src/components/Actions.js
@@ -134,15 +134,17 @@ export const Actions = () => {
                   Start
                 </Button>
               </div>
-              <div className="sui-g-grid__item">
-                <Button
-                  color="action-stop"
-                  onClick={() => stopJob()}
-                  isLoading={stopJobStatus === 'loading'}
-                >
-                  Stop
-                </Button>
-              </div>
+              {onStop && (
+                <div className="sui-g-grid__item">
+                  <Button
+                    color="action-stop"
+                    onClick={() => stopJob()}
+                    isLoading={stopJobStatus === 'loading'}
+                  >
+                    Stop
+                  </Button>
+                </div>
+              )}
               <div className="sui-g-grid__item">
                 <Button
                   onClick={() => getJobStatus()}
@@ -151,14 +153,16 @@ export const Actions = () => {
                   Get Status
                 </Button>
               </div>
-              <div className="sui-g-grid__item">
-                <Button
-                  onClick={() => getJobLogs()}
-                  isLoading={getJobLogsStatus === 'loading'}
-                >
-                  Get Logs
-                </Button>
-              </div>
+              {getLogs && (
+                <div className="sui-g-grid__item">
+                  <Button
+                    onClick={() => getJobLogs()}
+                    isLoading={getJobLogsStatus === 'loading'}
+                  >
+                    Get Logs
+                  </Button>
+                </div>
+              )}
               {jobStatus?.data && (
                 <div className="sui-g-grid__item">
                   {


### PR DESCRIPTION
Hide the Stop and Get Logs buttons if they are not declared in the
context.yaml.
Run and Get Status should always be available and must be implemented
by the external technology developer.

closes #31