### PR TITLE
📝 set the trust level to experimental

### DIFF
--- a/packages/sdk/src/cli/templates/context/context.yaml
+++ b/packages/sdk/src/cli/templates/context/context.yaml
@@ -2,7 +2,7 @@ id: {{id}}
 label: {{label}}
 description: "{{description}}"
 recommended: {{recommended}}
-trustLevel: stable
+trustLevel: experimental
 endpoint:
   features:
     - type: URL


### PR DESCRIPTION
external technologies must be experimental by default, so the
developer will only change it when it is finally ready

closes #38