### PR TITLE
🐛 fix metadata.yaml generation on build

### DIFF
--- a/packages/sdk/src/cli/utils/yaml.js
+++ b/packages/sdk/src/cli/utils/yaml.js
@@ -43,7 +43,7 @@ exports.generateMetadataFile = async () => {
   const technologiesPaths = await globby([`./${TECHNOLOGY.FILENAME_GLOB}`]) || [];
   const technologyPath = technologiesPaths[0];
 
-  const contextsPaths = await globby([`./**/${CONTEXT.FILENAME_GLOB}`]) || [];
+  const contextsPaths = await globby([`./**/${CONTEXT.FILENAME_GLOB}`, '!**/node_modules']) || [];
 
   const technologyContent = fse.readFileSync(technologyPath, 'utf8');
 


### PR DESCRIPTION
the build was taking the files in the node_modules and
appending it to the metadata.yaml

closes #48