### PR TITLE
🐛 change the type from JOB to EXTERNAL_JOB

### DIFF
--- a/packages/sdk/src/cli/templates/technology/technology.yaml
+++ b/packages/sdk/src/cli/templates/technology/technology.yaml
@@ -3,5 +3,5 @@ id: {{id}}
 label: {{label}}
 description: "{{description}}"
 available: true
-type: JOB
+type: EXTERNAL_JOB
 icon: job


### PR DESCRIPTION
Saagie requires an other technolgy type than JOB because it needs to
identifies if it is an internal or an external technolgy because
it does not handle them the same way

BREAKING CHANGE: Please update the existing technology on the
https://github.com/saagie/technologies repository

closes #51