### PR TITLE
fix(#54): implement path replacer on windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,10 @@
 ## Install dependencies
 
 ```sh
-yarn      # install npm dependencies
-yarn bs   # bootstrap repository with lerna to link local dependencies
-yarn link # to use saagie-sdk everywhere ;)
+yarn            # install npm dependencies
+yarn bs         # bootstrap repository with lerna to link local dependencies
+cd packages/sdk # go to the @saagie/sdk project
+yarn link       # to use saagie-sdk everywhere ;)
 ```
 
 ## Run tests
@@ -84,3 +85,16 @@ automatically create a new release on NPM and GitHub.
 2. Suppose we are currently at version `0.3.0`, and there are 2 PR one with the
    `patch` label and the other one with the `minor` label, then the released
    version will be `0.4.0`.
+
+## Troubleshooting
+
+### Windows
+
+`npm` uses `cmd` that doesn't support command substitution that we use to get
+the `git` commit hash for the build. You need to tell `npm` to use `powershell`
+for this to work. [Learn more here](https://github.com/kentcdodds/cross-env#windows-issues)
+and [here](https://github.com/kentcdodds/cross-env/issues/192#issuecomment-513341729).
+
+```
+npm config set script-shell "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The **Saagie Technology SDK** allows you to implements **new technologies** easi
 
 ## Requirements
 
-* **[Node.js](https://nodejs.org/)** - Minimum version: `12.15.0`
+* **[Node.js](https://nodejs.org/)** - Minimum version: `12.15.0` (the latest `lts` is recommended)
 
 ---
 

--- a/packages/sdk/src/cli/server/services/config.js
+++ b/packages/sdk/src/cli/server/services/config.js
@@ -1,17 +1,25 @@
+const { isWindows } = require('../../utils/isWindows');
+
 const yaml = require('../../utils/yaml');
 const { CONTEXT, TECHNOLOGY } = require('../../constants');
 
 module.exports = async (req, res) => {
-  const currentWorkingDirectory = process.cwd();
+  // globby do not work when it sees \\ (backslashes) so we replace all occurences
+  // of them with a simple / (slash). We do not want to replace \\ (backslashes)
+  // in Unix environment as it is a valid path.
+  let normalizedCurrentWorkingDirectory = process.cwd();
+  if (isWindows()) {
+    normalizedCurrentWorkingDirectory = normalizedCurrentWorkingDirectory.replace(/\\/g, '/');
+  }
 
   const technologiesData = await yaml.parseFilesToJSON({
-    folder: currentWorkingDirectory,
+    folder: normalizedCurrentWorkingDirectory,
     filename: TECHNOLOGY.FILENAME,
   });
   const technology = (technologiesData || [])[0];
 
   const contextsData = await yaml.parseFilesToJSON({
-    folder: currentWorkingDirectory,
+    folder: normalizedCurrentWorkingDirectory,
     filename: CONTEXT.FILENAME,
   });
 

--- a/packages/sdk/src/cli/utils/isWindows.js
+++ b/packages/sdk/src/cli/utils/isWindows.js
@@ -1,0 +1,5 @@
+const os = require('os');
+
+const isWindows = () => os.platform() === 'win32';
+
+exports.isWindows = isWindows;

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -18,8 +18,8 @@
     "uuid": "7.0.3"
   },
   "scripts": {
-    "dev": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts start",
-    "build": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts build",
+    "dev": "cross-env REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) react-scripts start",
+    "build": "cross-env REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) react-scripts build",
     "postbuild": "cp -r build/. ../sdk/build-webapp",
     "eject": "react-scripts eject",
     "lint": "eslint ./src",
@@ -42,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "cross-env": "7.0.2",
     "eslint": "6.8.0",
     "eslint-config-airbnb": "18.0.1",
     "eslint-plugin-import": "2.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5110,6 +5110,13 @@ create-react-context@<=0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-env@7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@7.0.1, cross-spawn@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -5137,6 +5144,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.4, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
+  integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"


### PR DESCRIPTION
globby do not work when path are using backslashes `\` so we
implemented a replacer on windows system so the paths are not
with backslashes

also implement a way to work on the sdk project using windows

closes #54