### PR TITLE
🐛 add portal to form control select

### DIFF
--- a/packages/sdk/src/cli/server/services/config.js
+++ b/packages/sdk/src/cli/server/services/config.js
@@ -24,7 +24,7 @@ module.exports = async (req, res) => {
   });
 
   const labelSortedContextData = contextsData.sort(
-    (a, b) => a && a.label && a.label.localeCompare(b && b.label),
+    (a, b) => a && a.label && a.label.toString().localeCompare(b && b.label),
   );
 
   res.send({ technology, contexts: labelSortedContextData });

--- a/packages/sdk/src/cli/server/services/demo.js
+++ b/packages/sdk/src/cli/server/services/demo.js
@@ -18,6 +18,9 @@ const datasets = [
   {
     id: '4', name: 'Fourth Dataset', status: undefined, logs: [],
   },
+  {
+    id: '5', name: 'Fifth Dataset with a very long name containing spaces. Helpful to check the behavior of the Select Box input type.', status: undefined, logs: [],
+  },
 ];
 
 const logs = [

--- a/packages/webapp/src/components/SmartField.js
+++ b/packages/webapp/src/components/SmartField.js
@@ -128,6 +128,9 @@ export const SmartField = ({
 
       return (
         <FormControlSelect
+          // Used to avoid long label to be cropped when selected. Closes #65.
+          // By adding this prop, it also remove the horizontal scrollbar.
+          menuPortalTarget={document.body}
           name={name}
           onChange={({ payload }) => {
             onUpdate({ name, value: payload });


### PR DESCRIPTION
By adding a menuPortalTarget to the FormControlSelect we avoid long
label to be cropped when selected. This also removes the horizontal
scrollbar.

closes #65