### PR TITLE
🐛 avoid concurrency request using uuid

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,6 +36,7 @@
     "semver": "7.3.2",
     "serve-static": "1.14.1",
     "slugify": "1.4.0",
+    "uuid": "8.1.0",
     "yaml": "1.8.3"
   },
   "devDependencies": {

--- a/packages/sdk/src/cli/server/services/action.js
+++ b/packages/sdk/src/cli/server/services/action.js
@@ -1,5 +1,6 @@
 const fse = require('fs-extra');
 const path = require('path');
+const { v4: uuidv4 } = require('uuid');
 const { Response } = require('../../../sdk');
 const output = require('../../utils/output');
 const { ENGINES } = require('../../utils/engines');
@@ -17,7 +18,11 @@ module.exports = async (req, res) => {
       return;
     }
 
-    const outfile = path.resolve(process.cwd(), BUNDLE_FOLDER, path.basename(req.body.script));
+    const outfile = path.resolve(
+      process.cwd(),
+      BUNDLE_FOLDER,
+      `${uuidv4()}-${path.basename(req.body.script)}`,
+    );
 
     const engine = ENGINES[global.bundler] || ENGINES[BUNDLERS.PARCEL];
 
@@ -42,6 +47,10 @@ module.exports = async (req, res) => {
       default:
         res.send(data);
     }
+
+    // Removing the outfile scripts because they are uniquely generated per
+    // request so we do not want to clutter the user disk space.
+    await fse.remove(outfile);
   } catch (err) {
     output.error(err);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16648,6 +16648,11 @@ uuid@7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
+uuid@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
+
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"


### PR DESCRIPTION
From now on, every request on action will compile javascript file using
a uuid for the path, return the value and will delete the file.

closes #83