### PR TITLE
✨ Implement Radio type field

### DIFF
--- a/packages/webapp/src/components/SmartField.js
+++ b/packages/webapp/src/components/SmartField.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import axios from 'axios';
 import {
   FormGroup,
+  FormCheck,
   FormControlInput,
   FormPassword,
   FormControlSelect,
@@ -88,6 +89,21 @@ export const SmartField = ({
 
   const getField = () => {
     switch (type) {
+    case 'RADIO': {
+      const selectProps = Array.isArray(options) ? options : [];
+      return (
+        selectProps?.map((radio) => (
+          <FormCheck
+            isRadio
+            key={radio.value}
+            value={radio.value}
+            name={name}
+            onChange={handleFormControlInput}
+          >{radio.label || ''}
+          </FormCheck>
+        ))
+      );
+    }
     case 'TEXTAREA':
       triggerInputDataFetching();
 

--- a/packages/webapp/src/components/SmartField.js
+++ b/packages/webapp/src/components/SmartField.js
@@ -90,15 +90,15 @@ export const SmartField = ({
   const getField = () => {
     switch (type) {
     case 'RADIO': {
-      const selectProps = Array.isArray(options) ? options : [];
+      const radioProps = Array.isArray(options) ? options : [];
       return (
-        selectProps?.map((radio) => (
+        radioProps?.map((radio) => (
           <FormCheck
             isRadio
             key={radio.value}
             value={radio.value}
             name={name}
-            onChange={handleFormControlInput}
+            onChange={(e) => onUpdate({ name, value: e.target.value })}
           >{radio.label || ''}
           </FormCheck>
         ))


### PR DESCRIPTION
From now on, Radio type is available for technology yaml setup.
It can be used with the keyword RADIO, with a list of "label"/"value" in "options" in the context.yaml.

closes #70