### PR TITLE
fix: release all packages on update

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "yarn build:webapp && yarn build:sdk",
     "build:webapp": "lerna run build --scope @saagie/sdk-webapp --stream",
     "build:sdk": "lerna run build --scope @saagie/sdk --stream",
-    "deploy": "yarn build && lerna publish",
+    "deploy": "yarn build && lerna publish --force-publish *",
     "dev": "lerna run dev --scope @saagie/* --stream --parallel",
     "lint": "lerna run lint --scope @saagie/* --stream --parallel -- --max-warnings 0",
     "test": "lerna run test --scope @saagie/* --stream --parallel",


### PR DESCRIPTION
last release didn't contains the webapp because the CLI wasn't updated,
and the webapp is built only when the CLI is updated, so we need to
force publish the CLI

closes #90