### PR TITLE
Add --no-verify-access for lerna publish

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,7 @@ if [ ! -z "$VERSION" ]; then
 
   echo 'Adding registry with authentication'
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-  yarn deploy --yes $VERSION -m '%v [skip ci]'
+  yarn deploy --no-verify-access --yes $VERSION -m '%v [skip ci]'
   auto release
 
   echo 'Remove registry with authentation'


### PR DESCRIPTION
Skip a call to a specific npm api to verify user access which seems to not work anymore when using a token authentication

https://github.com/lerna/lerna/issues/2788